### PR TITLE
imp(evm): adjust contract create protection to chain based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Dymension changes
 
 ### State Machine Breaking
-- (evm) Disabled contract creation.
+- (evm) [#3](https://github.com/dymensionxyz/ethermint/pull/3) Disabled contract creation
+- (evm) Disabled contract creation for Dymension chains only (adjust the absolute logic in [#3](https://github.com/dymensionxyz/ethermint/pull/3))
 
 ### Bug Fixes
 - (rpc) [#6](https://github.com/dymensionxyz/ethermint/pull/6) Zero gas config for tracing methods

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -100,7 +100,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 				tx := suite.CreateTestTx(signedContractTx, privKey, 1, false)
 				return tx
 			},
-			false, false, false,
+			false, false, true,
 		},
 		{
 			"success - CheckTx (contract)",
@@ -121,7 +121,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 				tx := suite.CreateTestTx(signedContractTx, privKey, 1, false)
 				return tx
 			},
-			true, false, false,
+			true, false, true,
 		},
 		{
 			"success - ReCheckTx (contract)",
@@ -982,7 +982,7 @@ func (suite AnteTestSuite) TestAnteHandlerWithDynamicTxFee() {
 				return tx
 			},
 			true,
-			false, false, false,
+			false, false, true,
 		},
 		{
 			"success - CheckTx (contract)",
@@ -1004,7 +1004,7 @@ func (suite AnteTestSuite) TestAnteHandlerWithDynamicTxFee() {
 				return tx
 			},
 			true,
-			true, false, false,
+			true, false, true,
 		},
 		{
 			"success - ReCheckTx (contract)",
@@ -1270,7 +1270,7 @@ func (suite AnteTestSuite) TestAnteHandlerWithParams() {
 				return tx
 			},
 			true, true,
-			evmtypes.ErrCreateDisabled,
+			nil,
 		},
 		{
 			"fail - EVM Call Disabled",
@@ -1325,14 +1325,6 @@ func (suite AnteTestSuite) TestAnteHandlerWithParams() {
 			suite.evmParamsOption = func(params *evmtypes.Params) {
 				params.EnableCall = tc.enableCall
 				params.EnableCreate = tc.enableCreate
-			}
-			if tc.enableCreate {
-				suite.Require().Panics(
-					func() {
-						suite.SetupTest()
-					},
-				)
-				return
 			}
 
 			suite.SetupTest()

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -280,8 +280,6 @@ func sendTestTransaction(t *testing.T) hexutil.Bytes {
 
 // deployTestContract deploys a contract that emits an event in the constructor
 func deployTestContract(t *testing.T) (hexutil.Bytes, map[string]interface{}) {
-	t.SkipNow()
-
 	gasPrice := GetGasPrice(t)
 	param := make([]map[string]string, 1)
 	param[0] = make(map[string]string)
@@ -387,8 +385,6 @@ var helloTopic = "0x775a94827b8fd9b519d36cd827093c664f93347070a554f65e4a6f56cd73
 var worldTopic = "0x0000000000000000000000000000000000000000000000000000000000000011"
 
 func deployTestContractWithFunction(t *testing.T) hexutil.Bytes {
-	t.SkipNow()
-
 	// pragma solidity ^0.5.1;
 
 	// contract Test {

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -185,8 +185,6 @@ func SendTestTransaction(t *testing.T, addr []byte) hexutil.Bytes {
 
 // deployTestContract deploys a contract that emits an event in the constructor
 func DeployTestContract(t *testing.T, addr []byte) (hexutil.Bytes, map[string]interface{}) {
-	t.SkipNow()
-
 	param := make([]map[string]string, 1)
 	param[0] = make(map[string]string)
 	param[0]["from"] = "0x" + fmt.Sprintf("%x", addr)
@@ -211,8 +209,6 @@ func DeployTestContract(t *testing.T, addr []byte) (hexutil.Bytes, map[string]in
 }
 
 func DeployTestContractWithFunction(t *testing.T, addr []byte) hexutil.Bytes {
-	t.SkipNow()
-
 	// pragma solidity ^0.5.1;
 
 	// contract Test {

--- a/utils/sdk_context.go
+++ b/utils/sdk_context.go
@@ -17,3 +17,21 @@ func UseZeroGasConfig(ctx sdk.Context) sdk.Context {
 func IsEthermintDevChain(ctx sdk.Context) bool {
 	return strings.HasPrefix(ctx.ChainID(), "ethermint_")
 }
+
+// IsOneOfDymensionChains returns true if the chain-id is one of the dymension chains:
+//   - Mainnet
+//   - Testnet Blumbus
+//   - Devnet Froopyland
+func IsOneOfDymensionChains(ctx sdk.Context) bool {
+	chainId := ctx.ChainID()
+	if strings.HasPrefix(chainId, "dymension_") {
+		return true
+	}
+	if strings.HasPrefix(chainId, "blumbus_") {
+		return true
+	}
+	if strings.HasPrefix(chainId, "froopyland_") {
+		return true
+	}
+	return false
+}

--- a/utils/sdk_context_test.go
+++ b/utils/sdk_context_test.go
@@ -24,3 +24,75 @@ func TestUseZeroGasConfig(t *testing.T) {
 
 	require.NotZero(t, ctx.KVGasConfig().ReadCostFlat, "the change should not effect the original context")
 }
+
+func TestIsChain(t *testing.T) {
+	tests := []struct {
+		name                       string
+		chainId                    string
+		wantIsEthermintDevChain    bool
+		wantIsOneOfDymensionChains bool
+	}{
+		{
+			name:                       "Dymension Mainnet",
+			chainId:                    "dymension_1100-1",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: true,
+		},
+		{
+			name:                       "Dymension Mainnet",
+			chainId:                    "dymension_1100-2",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: true,
+		},
+		{
+			name:                       "Dymension Mainnet",
+			chainId:                    "dymension_1-2",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: true,
+		},
+		{
+			name:                       "Dymension Testnet Blumbus",
+			chainId:                    "blumbus_111-1",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: true,
+		},
+		{
+			name:                       "Dymension Devnet Froopyland",
+			chainId:                    "froopyland_100-1",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: true,
+		},
+		{
+			name:                       "Ethermint Devnet",
+			chainId:                    "ethermint_9000-1",
+			wantIsEthermintDevChain:    true,
+			wantIsOneOfDymensionChains: false,
+		},
+		{
+			name:                       "Cosmos",
+			chainId:                    "cosmoshub-4",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: false,
+		},
+		{
+			name:                       "Evmos Mainnet",
+			chainId:                    "evmos_9001-2",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: false,
+		},
+		{
+			name:                       "Evmos Testnet",
+			chainId:                    "evmos_9000-4",
+			wantIsEthermintDevChain:    false,
+			wantIsOneOfDymensionChains: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sdkCtx := sdk.Context{}
+			sdkCtx = sdkCtx.WithChainID(tt.chainId)
+			require.Equal(t, tt.wantIsEthermintDevChain, IsEthermintDevChain(sdkCtx))
+			require.Equal(t, tt.wantIsOneOfDymensionChains, IsOneOfDymensionChains(sdkCtx))
+		})
+	}
+}

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -40,6 +40,10 @@ func InitGenesis(
 	bankKeeper types.BankKeeper,
 	data types.GenesisState,
 ) []abci.ValidatorUpdate {
+	if utils.IsOneOfDymensionChains(ctx) && data.Params.EnableCreate {
+		panic(fmt.Errorf("enable create is not allowed on Dymension chains"))
+	}
+
 	k.WithChainID(ctx)
 
 	err := k.SetParams(ctx, data.Params)

--- a/x/evm/genesis_test.go
+++ b/x/evm/genesis_test.go
@@ -1,6 +1,8 @@
 package evm_test
 
 import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -158,6 +160,66 @@ func (suite *EvmTestSuite) TestInitGenesis() {
 						_ = evm.InitGenesis(suite.ctx, suite.app.EvmKeeper, suite.app.AccountKeeper, suite.app.BankKeeper, *tc.genState)
 					},
 				)
+			}
+		})
+	}
+
+	originalCtx := suite.ctx
+	testCasesProhibitEnableCreate := []struct {
+		name      string
+		chainId   string
+		wantPanic bool
+	}{
+		{
+			name:      "Dymension Mainnet",
+			chainId:   "dymension_1100-1",
+			wantPanic: true,
+		},
+		{
+			name:      "Dymension Testnet Blumbus",
+			chainId:   "blumbus_111-1",
+			wantPanic: true,
+		},
+		{
+			name:      "Dymension Devnet Froopyland",
+			chainId:   "froopyland_100-1",
+			wantPanic: true,
+		},
+		{
+			name:      "Ethermint Devnet",
+			chainId:   "ethermint_9000-1",
+			wantPanic: false,
+		},
+	}
+	for _, tt := range testCasesProhibitEnableCreate {
+		suite.Run(tt.name, func() {
+			suite.SetupTest()
+			suite.ctx = suite.ctx.WithChainID(tt.chainId)
+
+			genesisState := types.DefaultGenesisState()
+			suite.Require().True(genesisState.Params.EnableCreate, "Enable create must be enabled by default")
+
+			var ctx sdk.Context
+			if tt.chainId != "" {
+				ctx = suite.ctx.WithChainID(tt.chainId)
+			} else {
+				ctx = originalCtx
+			}
+
+			init := func() {
+				_ = evm.InitGenesis(ctx, suite.app.EvmKeeper, suite.app.AccountKeeper, suite.app.BankKeeper, *genesisState)
+			}
+
+			if tt.wantPanic {
+				defer func() {
+					err := recover()
+					suite.Require().NotNil(err, "expected panic")
+					suite.Require().Contains(fmt.Sprintf("%v", err), "enable create is not allowed on Dymension chains")
+				}()
+
+				init()
+			} else {
+				suite.Require().NotPanics(init)
 			}
 		})
 	}

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -257,7 +257,6 @@ func (suite *EvmTestSuite) TestHandleMsgEthereumTx() {
 }
 
 func (suite *EvmTestSuite) TestHandlerLogs() {
-	suite.T().SkipNow()
 	// Test contract:
 
 	// pragma solidity ^0.5.1;
@@ -297,8 +296,6 @@ func (suite *EvmTestSuite) TestHandlerLogs() {
 }
 
 func (suite *EvmTestSuite) TestDeployAndCallContract() {
-	suite.T().SkipNow()
-
 	// Test contract:
 	//http://remix.ethereum.org/#optimize=false&evmVersion=istanbul&version=soljson-v0.5.15+commit.6a57276f.js
 	//2_Owner.sol
@@ -418,8 +415,6 @@ func (suite *EvmTestSuite) TestSendTransaction() {
 }
 
 func (suite *EvmTestSuite) TestOutOfGasWhenDeployContract() {
-	suite.T().SkipNow()
-
 	// Test contract:
 	//http://remix.ethereum.org/#optimize=false&evmVersion=istanbul&version=soljson-v0.5.15+commit.6a57276f.js
 	//2_Owner.sol
@@ -496,8 +491,6 @@ func (suite *EvmTestSuite) TestOutOfGasWhenDeployContract() {
 }
 
 func (suite *EvmTestSuite) TestErrorWhenDeployContract() {
-	suite.T().SkipNow()
-
 	gasLimit := uint64(1000000)
 	gasPrice := big.NewInt(10000)
 
@@ -517,8 +510,6 @@ func (suite *EvmTestSuite) TestErrorWhenDeployContract() {
 }
 
 func (suite *EvmTestSuite) deployERC20Contract() common.Address {
-	suite.T().SkipNow()
-
 	k := suite.app.EvmKeeper
 	nonce := k.GetNonce(suite.ctx, suite.from)
 	ctorArgs, err := types.ERC20Contract.ABI.Pack("", suite.from, big.NewInt(10000000000))
@@ -643,8 +634,6 @@ func (suite *EvmTestSuite) TestERC20TransferReverted() {
 }
 
 func (suite *EvmTestSuite) TestContractDeploymentRevert() {
-	suite.T().SkipNow()
-
 	intrinsicGas := uint64(134180)
 	testCases := []struct {
 		msg      string

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -490,8 +490,6 @@ func (suite *KeeperTestSuite) TestQueryValidatorAccount() {
 }
 
 func (suite *KeeperTestSuite) TestEstimateGas() {
-	suite.T().SkipNow()
-
 	gasHelper := hexutil.Uint64(20000)
 	higherGas := hexutil.Uint64(25000)
 	hexBigInt := hexutil.Big(*big.NewInt(1))

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -258,8 +258,6 @@ func (suite *KeeperTestSuite) StateDB() *statedb.StateDB {
 
 // DeployTestContract deploy a test erc20 contract and returns the contract address
 func (suite *KeeperTestSuite) DeployTestContract(t *testing.T, owner common.Address, supply *big.Int) common.Address {
-	t.SkipNow()
-
 	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/evmos/ethermint/utils"
 	"strconv"
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -153,6 +154,13 @@ func (k *Keeper) UpdateParams(goCtx context.Context, req *types.MsgUpdateParams)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if utils.IsOneOfDymensionChains(ctx) {
+		if req.Params.EnableCreate {
+			return nil, errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "Enable Create is not allowed")
+		}
+	}
+
 	if err := k.SetParams(ctx, req.Params); err != nil {
 		return nil, err
 	}

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"math/big"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -83,8 +84,11 @@ func (suite *KeeperTestSuite) TestEthereumTx() {
 }
 
 func (suite *KeeperTestSuite) TestUpdateParams() {
+	originalCtx := suite.ctx
+
 	testCases := []struct {
 		name      string
+		chainId   string
 		request   *types.MsgUpdateParams
 		expectErr bool
 	}{
@@ -101,12 +105,56 @@ func (suite *KeeperTestSuite) TestUpdateParams() {
 			},
 			expectErr: false,
 		},
+		{
+			name:    "fail - valid Update msg but EnableCreate must be disabled on Dymension chain",
+			chainId: "dymension_1100-1",
+			request: &types.MsgUpdateParams{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Params:    types.DefaultParams(),
+			},
+			expectErr: true,
+		},
+		{
+			name:    "fail - valid Update msg but EnableCreate must be disabled on Blumbus chain",
+			chainId: "blumbus_111-1",
+			request: &types.MsgUpdateParams{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Params:    types.DefaultParams(),
+			},
+			expectErr: true,
+		},
+		{
+			name:    "fail - valid Update msg but EnableCreate must be disabled on Froopyland chain",
+			chainId: "froopyland_100-1",
+			request: &types.MsgUpdateParams{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Params:    types.DefaultParams(),
+			},
+			expectErr: true,
+		},
+		{
+			name:    "pass - valid Update msg, can enable create on Ethermint dev chain",
+			chainId: "ethermint_9000-1",
+			request: &types.MsgUpdateParams{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Params:    types.DefaultParams(),
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run("MsgUpdateParams", func() {
-			_, err := suite.app.EvmKeeper.UpdateParams(suite.ctx, tc.request)
+			var ctx sdk.Context
+
+			if tc.chainId != "" {
+				ctx = suite.ctx.WithChainID(tc.chainId)
+			} else {
+				ctx = originalCtx
+			}
+
+			_, err := suite.app.EvmKeeper.UpdateParams(ctx, tc.request)
 			if tc.expectErr {
 				suite.Require().Error(err)
 			} else {

--- a/x/evm/types/params.go
+++ b/x/evm/types/params.go
@@ -31,7 +31,7 @@ var (
 	// DefaultAllowUnprotectedTxs rejects all unprotected txs (i.e false)
 	DefaultAllowUnprotectedTxs = false
 	// DefaultEnableCreate enables contract creation (i.e true)
-	DefaultEnableCreate = false
+	DefaultEnableCreate = true
 	// DefaultEnableCall enables contract calls (i.e true)
 	DefaultEnableCall = true
 )
@@ -84,9 +84,6 @@ func (p Params) Validate() error {
 
 	if err := validateBool(p.EnableCreate); err != nil {
 		return err
-	}
-	if p.EnableCreate {
-		return fmt.Errorf("contract creation is disabled")
 	}
 
 	if err := validateBool(p.AllowUnprotectedTxs); err != nil {

--- a/x/evm/types/params_test.go
+++ b/x/evm/types/params_test.go
@@ -18,7 +18,7 @@ func TestParamsValidate(t *testing.T) {
 		{"default", DefaultParams(), false},
 		{
 			"valid",
-			NewParams("ara", false, false, true, DefaultChainConfig(), extraEips),
+			NewParams("ara", false, true, true, DefaultChainConfig(), extraEips),
 			false,
 		},
 		{
@@ -39,11 +39,6 @@ func TestParamsValidate(t *testing.T) {
 				EvmDenom:  "stake",
 				ExtraEIPs: []int64{1},
 			},
-			true,
-		},
-		{
-			"creation not allowed",
-			NewParams("ara", false, true, true, DefaultChainConfig(), extraEips),
 			true,
 		},
 	}


### PR DESCRIPTION
Previous logic:
- Absolutely disabled `EnableCreate` on `x/evm` params.

New logic:
- `EnableCreate = true` is not allowed on Dymension chains, checked by Chain-ID:
  - Mainnet prefix `dymension_`
  - Testnet prefix `blumbus_`
  - Devnet prefix `froopyland_`